### PR TITLE
Update phq9_schema.jsonld with variable map

### DIFF
--- a/activities/PHQ-9/phq9_schema.jsonld
+++ b/activities/PHQ-9/phq9_schema.jsonld
@@ -1,6 +1,7 @@
 {
     "@context": [ "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/contexts/generic.jsonld",
-        "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_context.jsonld"
+        "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_context.jsonld",
+        "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/contexts/prototypes.jsonld"
     ],
     "@type": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld",
     "@id": "phq9_schema",
@@ -38,6 +39,18 @@
             "phq9_8": true,
             "phq9_9": true,
             "phq9_10": "phq9_1 > 0 ||  phq9_2 > 0 || phq9_3 > 0 || phq9_4 > 0 || phq9_5 > 0 || phq9_6 > 0 || phq9_7 > 0 || phq9_8 > 0 || phq9_9 > 0"
+        },
+        "variableMap": {
+            "phq9_1": "phq9_1",
+            "phq9_2": "phq9_2",
+            "phq9_3": "phq9_3",
+            "phq9_4": "phq9_4",
+            "phq9_5": "phq9_5",
+            "phq9_6": "phq9_6",
+            "phq9_7": "phq9_7",
+            "phq9_8": "phq9_8",
+            "phq9_9": "phq9_9",
+            "phq9_10": "phq9_10"
         }
     }
 }


### PR DESCRIPTION
this would expand to:
<img width="851" alt="Screen Shot 2019-04-15 at 8 43 14 AM" src="https://user-images.githubusercontent.com/972008/56146148-900d5900-5f5a-11e9-8036-4a92a82e358b.png">

which means the jsonld files can have weird names (key names) but would map to names we can use in equations (`@id` here has an extra starting `/`, but thats fine i think).

@satra would you still consider this a hack?
