### PR TITLE
Remove incorrect URIs

### DIFF
--- a/activity-sets/cognitive-tasks/cognitive-tasks_context.jsonld
+++ b/activity-sets/cognitive-tasks/cognitive-tasks_context.jsonld
@@ -1,6 +1,6 @@
 {
     "@context": {
-        "activity_path": "https://raw.githubusercontent.com/stufreen/schema-standardization/master/activities/",
+        "activity_path": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/",
         "flanker_schema": {
             "@id": "activity_path:FlankerExample/FlankerExample_schema.jsonld",
             "@type": "@id"

--- a/activity-sets/cognitive-tasks/cognitive-tasks_schema.jsonld
+++ b/activity-sets/cognitive-tasks/cognitive-tasks_schema.jsonld
@@ -1,7 +1,7 @@
 {
     "@context": [
         "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/contexts/generic.jsonld",
-        "https://raw.githubusercontent.com/stufreen/schema-standardization/master/activity-sets/cognitive-tasks/cognitive-tasks_context.jsonld"
+        "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/cognitive-tasks/cognitive-tasks_context.jsonld"
     ],
     "@type": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/ActivitySet.jsonld",
     "@id": "cognitive-tasks_schema",
@@ -10,7 +10,7 @@
     "schema:description": "Participate in a variety of cognitive tasks.",
     "schema:schemaVersion": "0.0.1",
     "schema:version": "0.0.1",
-    "schema:image": "https://raw.githubusercontent.com/stufreen/schema-standardization/master/activity-sets/cognitive-tasks/cognitive-tasks_image.jpg",
+    "schema:image": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/cognitive-tasks/cognitive-tasks_image.jpg",
     "ui": {
         "order": [
             "flanker_schema"


### PR DESCRIPTION
While in development I was using my fork (`stufreen/schema-standardization`) to test. This PR changes all URIs to `ReproNim/schema-standardization` as the changes have now been merged in.