### PR TITLE
Re-add allow to context; Update allow values

### DIFF
--- a/activities/FlankerExample/FlankerExample_schema.jsonld
+++ b/activities/FlankerExample/FlankerExample_schema.jsonld
@@ -43,6 +43,7 @@
       "flanker_practice": true,
       "test_instructions": true,
       "flanker_test": true
-    }
+    },
+    "allow": ["disableBack"]
   }
 }

--- a/activities/FlankerExample/items/flanker_practice.jsonld
+++ b/activities/FlankerExample/items/flanker_practice.jsonld
@@ -10,7 +10,8 @@
   "schema:schemaVersion": "0.0.1",
   "schema:version": "0.0.1",
   "ui": {
-    "inputType": "visual-stimulus-response"
+    "inputType": "visual-stimulus-response",
+    "allow": ["skipped", "autoAdvance"]
   },
   "inputOptions": [
     {

--- a/activities/FlankerExample/items/flanker_test.jsonld
+++ b/activities/FlankerExample/items/flanker_test.jsonld
@@ -10,7 +10,11 @@
   "schema:schemaVersion": "0.0.1",
   "schema:version": "0.0.1",
   "ui": {
-    "inputType": "visual-stimulus-response"
+    "inputType": "visual-stimulus-response",
+    "allow": [
+      "fullScreen",
+      "autoAdvance"
+    ]
   },
   "inputOptions": [
     {

--- a/activities/RAVLT/RAVLT_schema.jsonld
+++ b/activities/RAVLT/RAVLT_schema.jsonld
@@ -115,6 +115,7 @@
       "ravlt_recording_6": true,
       "ravlt_stimulus_7": true,
       "ravlt_recording_7": true
-    }
+    },
+    "allow": ["disableBack"]
   }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_1.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_1.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
       "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/activities/RAVLT/items/ravlt_stimulus_2.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_2.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
       "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/activities/RAVLT/items/ravlt_stimulus_3.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_3.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
       "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/activities/RAVLT/items/ravlt_stimulus_4.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_4.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
       "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/activities/RAVLT/items/ravlt_stimulus_5.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_5.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
       "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/activities/RAVLT/items/ravlt_stimulus_6.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_6.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-b.mp3",
       "schema:transcript": "Desk, Ranger, Bird, Shoe, Stove, Mountain, Glasses, Towel, Cloud, Boat, Lamb, Gun, Pencil, Church, Fish."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/activities/RAVLT/items/ravlt_stimulus_7.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_7.jsonld
@@ -13,7 +13,8 @@
     "en": "Press the Play button below to listen to a list of words."
   },
   "ui": {
-    "inputType": "audioStimulus"
+    "inputType": "audioStimulus",
+    "allow": ["autoAdvance"]
   },
   "inputOptions": [
     {
@@ -21,11 +22,6 @@
       "schema:name": "stimulus",
       "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
       "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
-    },
-    {
-      "@type": "schema:Boolean",
-      "schema:name": "autoAdvance",
-      "schema:value": true
     },
     {
       "@type": "schema:Boolean",

--- a/contexts/generic.jsonld
+++ b/contexts/generic.jsonld
@@ -116,14 +116,18 @@
             "@container": "@index",
             "@nest": "ui"
         },
-        "addStatus": {
-            "@id": "https://schema.repronim.org/addStatus",
-            "@container": "@index",
+        "allow": {
+            "@id": "https://schema.repronim.org/allow",
+            "@container": "@list",
+            "@type": "@vocab",
             "@nest": "ui"
         },
         "skipped": "https://schema.repronim.org/refused_to_answer",
         "dontKnow": "https://schema.repronim.org/dont_know_answer",
         "timedOut": "https://schema.repronim.org/timed_out",
+        "fullScreen": "https://schema.repronim.org/full_screen",
+        "autoAdvance": "https://schema.repronim.org/auto_advance",
+        "disableBack": "https://schema.repronim.org/disable_back",
         "method": "schema:httpMethod",
         "url": "schema:url",
         "payload": "https://schema.repronim.org/payload",


### PR DESCRIPTION
The `allow` value was removed from the `generic` context at some point, but it was being used for skipping control.

This PR re-adds the `allow` value to the generic context, and adds some related controls like `fullScreen`, `autoAdvance`, and `disableBack`. These can be set at the Item level or the Activity level.