### PR TITLE
Adds media list for RAVLT cognitive task

### DIFF
--- a/activities/RAVLT/items/ravlt_stimulus_1.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_1.jsonld
@@ -18,15 +18,23 @@
   },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
-      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+    }
+  }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_2.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_2.jsonld
@@ -18,15 +18,23 @@
   },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
-      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+    }
+  }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_3.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_3.jsonld
@@ -12,21 +12,25 @@
   "question": {
     "en": "Press the Play button below to listen to a list of words."
   },
-  "ui": {
-    "inputType": "audioStimulus",
-    "allow": ["autoAdvance"]
-  },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
-      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+    }
+  }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_4.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_4.jsonld
@@ -18,15 +18,23 @@
   },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
-      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+    }
+  }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_5.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_5.jsonld
@@ -18,15 +18,23 @@
   },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
-      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+    }
+  }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_6.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_6.jsonld
@@ -18,15 +18,23 @@
   },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-b.mp3",
-      "schema:transcript": "Desk, Ranger, Bird, Shoe, Stove, Mountain, Glasses, Towel, Cloud, Boat, Lamb, Gun, Pencil, Church, Fish."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-b.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-b.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-b.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-b.mp3",
+      "schema:transcript": "Desk, Ranger, Bird, Shoe, Stove, Mountain, Glasses, Towel, Cloud, Boat, Lamb, Gun, Pencil, Church, Fish."
+    }
+  }
 }

--- a/activities/RAVLT/items/ravlt_stimulus_7.jsonld
+++ b/activities/RAVLT/items/ravlt_stimulus_7.jsonld
@@ -18,15 +18,23 @@
   },
   "inputOptions": [
     {
-      "@type": "schema:AudioObject",
+      "@type": "schema:URL",
       "schema:name": "stimulus",
-      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
-      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+      "schema:value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3"
     },
     {
       "@type": "schema:Boolean",
       "schema:name": "allowReplay",
       "schema:value": false
     }
-  ]
+  ],
+  "media": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3": {
+      "@type": "schema:AudioObject",
+      "schema:name": "stimulus",
+      "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/RAVLT/items/ravlt-a.mp3",
+      "schema:transcript": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+    }
+  }
 }


### PR DESCRIPTION
Adding a media list to a schema item signals the client that it should pre-download the media, allowing for offline usage.