### PR TITLE
fix context for tables

### DIFF
--- a/contexts/generic
+++ b/contexts/generic
@@ -92,19 +92,16 @@
             "@type": "xsd:int",
             "@nest": "ui"
         },
-        "render": "@nest",
-        "table": "@nest",
         "headers": {
             "@id": "https://schema.repronim.org/tableheaders",
             "@container": "@list",
-            "@type": "@vocab",
-            "@nest": "table"
+            "@nest": "ui"
         },
         "rows": {
             "@id": "https://schema.repronim.org/tablerows",
             "@container": "@list",
             "@type": "@vocab",
-            "@nest": "table"
+            "@nest": "ui"
         },
         "branchLogic": {
             "@id": "https://schema.repronim.org/branchLogic",


### PR DESCRIPTION
the generic context hadn't been changed to suit the latest implementation of inputType table elements and so a previous way of doing it was merged. this PR changes the context to fit the current implementation