### PR TITLE
MedicalHistory activity context: directly link IRI

### DIFF
--- a/activities/MedicalHistory-LORIS/medicalhistory_context
+++ b/activities/MedicalHistory-LORIS/medicalhistory_context
@@ -24,7 +24,7 @@
         "medicalhistory_sectionA": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionA",
         "medicalhistory_sectionB": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionB",
         "medicalhistory_sectionC": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionC",
-        "medicalhistory_sectionD": {"https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD",
+        "medicalhistory_sectionD": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD",
         "medicalhistory_page1": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page1",
         "medicalhistory_page2": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page2",
         "medicalhistory_page3": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page3",

--- a/activities/MedicalHistory-LORIS/medicalhistory_context
+++ b/activities/MedicalHistory-LORIS/medicalhistory_context
@@ -27,7 +27,6 @@
         "medicalhistory_sectionD": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD",
         "medicalhistory_page1": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page1",
         "medicalhistory_page2": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page2",
-        "medicalhistory_page3": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page3",
-        "not_answered": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/not_answered"
+        "medicalhistory_page3": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page3"
     }
 }

--- a/activities/MedicalHistory-LORIS/medicalhistory_context
+++ b/activities/MedicalHistory-LORIS/medicalhistory_context
@@ -3,104 +3,79 @@
         "@version": 1.1,
         "items": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/items/",
         "medicalhistory_1": {
-            "@id": "items:medicalhistory_1",
-            "@type": "@id"
+            "@id": "items:medicalhistory_1"
         },
         "medicalhistory_1a": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
         },
         "medicalhistory_2": {
-            "@id": "items:medicalhistory_2",
-            "@type": "@id"
+            "@id": "items:medicalhistory_2"
         },
         "medicalhistory_2a": {
-            "@id": "items:medicalhistory_2a",
-            "@type": "@id"
+            "@id": "items:medicalhistory_2a"
         },
         "medicalhistory_7": {
-            "@id": "items:medicalhistory_7",
-            "@type": "@id"
+            "@id": "items:medicalhistory_7"
         },
         "medicalhistory_7a": {
-            "@id": "items:medicalhistory_7a",
-            "@type": "@id"
+            "@id": "items:medicalhistory_7a"
         },
         "medicalhistory_7b": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
         },
         "medicalhistory_21": {
-            "@id": "items:medicalhistory_21",
-            "@type": "@id"
+            "@id": "items:medicalhistory_21"
         },
         "medicalhistory_21a_incident": {
-            "@id": "items:medicalhistory_incident",
-            "@type": "@id"
+            "@id": "items:medicalhistory_incident"
         },
         "medicalhistory_21a_hospitalized": {
-            "@id": "items:medicalhistory_hospitalized",
-            "@type": "@id"
+            "@id": "items:medicalhistory_hospitalized"
         },
         "medicalhistory_21a_age": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
         },
         "medicalhistory_21b_incident": {
-            "@id": "items:medicalhistory_incident",
-            "@type": "@id"
+            "@id": "items:medicalhistory_incident"
         },
         "medicalhistory_21b_hospitalized": {
-            "@id": "items:medicalhistory_hospitalized",
-            "@type": "@id"
+            "@id": "items:medicalhistory_hospitalized"
         },
         "medicalhistory_21b_age": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
         },
         "medicalhistory_21c_incident": {
-            "@id": "items:medicalhistory_incident",
-            "@type": "@id"
+            "@id": "items:medicalhistory_incident"
         },
         "medicalhistory_21c_hospitalized": {
-            "@id": "items:medicalhistory_hospitalized",
-            "@type": "@id"
+            "@id": "items:medicalhistory_hospitalized"
         },
         "medicalhistory_21c_age": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
         },
         "medicalhistory_21d": {
-            "@id": "items:medicalhistory_21d",
-            "@type": "@id"
+            "@id": "items:medicalhistory_21d"
         },
         "medicalhistory_concussion_table": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_concussion_table",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_concussion_table"
         },
         "medicalhistory_sectionA": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionA",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionA"
         },
         "medicalhistory_sectionB": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionB",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionB"
         },
         "medicalhistory_sectionC": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionC",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionC"
         },
         "medicalhistory_sectionD": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD"
         },
         "medicalhistory_page1": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page1",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page1"
         },
         "medicalhistory_page2": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page2",
-            "@type": "@id"
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page2"
         },
         "medicalhistory_page3": {
             "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page3",

--- a/activities/MedicalHistory-LORIS/medicalhistory_context
+++ b/activities/MedicalHistory-LORIS/medicalhistory_context
@@ -2,84 +2,32 @@
     "@context": {
         "@version": 1.1,
         "items": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/items/",
-        "medicalhistory_1": {
-            "@id": "items:medicalhistory_1"
-        },
-        "medicalhistory_1a": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
-        },
-        "medicalhistory_2": {
-            "@id": "items:medicalhistory_2"
-        },
-        "medicalhistory_2a": {
-            "@id": "items:medicalhistory_2a"
-        },
-        "medicalhistory_7": {
-            "@id": "items:medicalhistory_7"
-        },
-        "medicalhistory_7a": {
-            "@id": "items:medicalhistory_7a"
-        },
-        "medicalhistory_7b": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
-        },
-        "medicalhistory_21": {
-            "@id": "items:medicalhistory_21"
-        },
-        "medicalhistory_21a_incident": {
-            "@id": "items:medicalhistory_incident"
-        },
-        "medicalhistory_21a_hospitalized": {
-            "@id": "items:medicalhistory_hospitalized"
-        },
-        "medicalhistory_21a_age": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
-        },
-        "medicalhistory_21b_incident": {
-            "@id": "items:medicalhistory_incident"
-        },
-        "medicalhistory_21b_hospitalized": {
-            "@id": "items:medicalhistory_hospitalized"
-        },
-        "medicalhistory_21b_age": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
-        },
-        "medicalhistory_21c_incident": {
-            "@id": "items:medicalhistory_incident"
-        },
-        "medicalhistory_21c_hospitalized": {
-            "@id": "items:medicalhistory_hospitalized"
-        },
-        "medicalhistory_21c_age": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text"
-        },
-        "medicalhistory_21d": {
-            "@id": "items:medicalhistory_21d"
-        },
-        "medicalhistory_concussion_table": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_concussion_table"
-        },
-        "medicalhistory_sectionA": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionA"
-        },
-        "medicalhistory_sectionB": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionB"
-        },
-        "medicalhistory_sectionC": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionC"
-        },
-        "medicalhistory_sectionD": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD"
-        },
-        "medicalhistory_page1": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page1"
-        },
-        "medicalhistory_page2": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page2"
-        },
-        "medicalhistory_page3": {
-            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page3",
-            "@type": "@id"
-        }
+        "medicalhistory_1": "items:medicalhistory_1",
+        "medicalhistory_1a": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
+        "medicalhistory_2": "items:medicalhistory_2",
+        "medicalhistory_2a": "items:medicalhistory_2a",
+        "medicalhistory_7": "items:medicalhistory_7",
+        "medicalhistory_7a": "items:medicalhistory_7a",
+        "medicalhistory_7b": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
+        "medicalhistory_21": "items:medicalhistory_21",
+        "medicalhistory_21a_incident": "items:medicalhistory_incident",
+        "medicalhistory_21a_hospitalized": "items:medicalhistory_hospitalized",
+        "medicalhistory_21a_age": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
+        "medicalhistory_21b_incident": "items:medicalhistory_incident",
+        "medicalhistory_21b_hospitalized": "items:medicalhistory_hospitalized",
+        "medicalhistory_21b_age": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
+        "medicalhistory_21c_incident": "items:medicalhistory_incident",
+        "medicalhistory_21c_hospitalized": "items:medicalhistory_hospitalized",
+        "medicalhistory_21c_age": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/age_text",
+        "medicalhistory_21d": "items:medicalhistory_21d",
+        "medicalhistory_concussion_table": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_concussion_table",
+        "medicalhistory_sectionA": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionA",
+        "medicalhistory_sectionB": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionB",
+        "medicalhistory_sectionC": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionC",
+        "medicalhistory_sectionD": {"https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_sectionD",
+        "medicalhistory_page1": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page1",
+        "medicalhistory_page2": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page2",
+        "medicalhistory_page3": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/MedicalHistory-LORIS/medicalhistory_page3",
+        "not_answered": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/items/not_answered"
     }
 }


### PR DESCRIPTION
I'm removing the "@type: @id" line because the compact/relative IRI for the nodes should just link to the node identifier and isn't itself a term that is to be expanded to an IRI such as like `www.schema.org/DataType`

